### PR TITLE
fix sync_request in multi threading

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -451,9 +451,11 @@ class Connection(object):
             # lock or wait for signal
             if self._sync_lock.acquire(False):
                 self._sync_event.clear()
-                self.serve(remaining_time)
-                self._sync_lock.release()
-                self._sync_event.set()
+                try:
+                    self.serve(remaining_time)
+                finally:
+                    self._sync_lock.release()
+                    self._sync_event.set()
             else:
                 self._sync_event.wait(remaining_time)
 

--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -445,7 +445,7 @@ class Connection(object):
         start_time = time.time()
         while seq not in self._sync_replies:
             remaining_time = self.SYNC_REQUEST_TIMEOUT - (time.time() - start_time)
-            if remaining_time > self.SYNC_REQUEST_TIMEOUT:
+            if remaining_time < 0:
                 raise socket.timeout
 
             # lock or wait for signal


### PR DESCRIPTION
When two threads send sync_requests  at the same time, one of them waits for the other to finish serving. If the second response is faster than the first, the first thread will receive and store the second response. The second thread did not realize this and waits for his response for ever.