### PR TITLE
fixed failed function teleportation when matching module did not exist on the other side

### DIFF
--- a/rpyc/utils/teleportation.py
+++ b/rpyc/utils/teleportation.py
@@ -117,7 +117,10 @@ def _import_codetup(codetup):
 
 def import_function(functup):
     name, modname, defaults, codetup = functup
-    mod = __import__(modname, None, None, "*")
+    try:
+        mod = __import__(modname, None, None, "*")
+    except ImportError:
+        mod = __import__("__main__", None, None, "*")
     codeobj = _import_codetup(codetup)
     return FunctionType(codeobj, mod.__dict__, name, defaults)
 


### PR DESCRIPTION
teleport_function would fail the the supplied function has __module__ that does not exist on the other side