### PR TITLE
Make __str__ for exceptions less verbose (no remote part) while __repr__ stays unchanged

### DIFF
--- a/rpyc/core/vinegar.py
+++ b/rpyc/core/vinegar.py
@@ -177,12 +177,13 @@ def _get_exception_class(cls):
                 text = cls.__str__(self)
             except Exception:
                 text = "<Unprintable exception>"
+            return text
+        def __repr__(self):
+            text = str(self)
             if hasattr(self, "_remote_tb"):
                 text += "\n\n========= Remote Traceback (%d) =========\n%s" % (
                     self._remote_tb.count("\n\n========= Remote Traceback") + 1, self._remote_tb)
             return text
-        def __repr__(self):
-            return str(self)
     
     Derived.__name__ = cls.__name__
     Derived.__module__ = cls.__module__


### PR DESCRIPTION
What about this change ? I have users that are complaining that the messages are too verbose in 3.3, as every little message like ".. does not exist" (they made a typo) comes with a kilometer of remote back trace. It's extremely nice to have the backtrace for logs and devers, but the default printing should probably not have it. Hence my proposal to distinguish __str__ and __repr__ outputs.