### PR TITLE
Fix for on_service_removed() callback

### DIFF
--- a/rpyc/utils/registry.py
+++ b/rpyc/utils/registry.py
@@ -70,10 +70,10 @@ class RegistryServer(object):
         self.services[name].pop(addrinfo, None)
         if not self.services[name]:
             del self.services[name]
-        try:
-            self.on_service_removed(name, addrinfo)
-        except Exception:
-            self.logger.exception('error executing service remove callback')
+            try:
+                self.on_service_removed(name, addrinfo)
+            except Exception:
+                self.logger.exception('error executing service remove callback')
 
     def cmd_query(self, host, name):
         """implementation of the ``query`` command"""


### PR DESCRIPTION
Moved the try/except block inside the if block. This should fix the issue with the on_service_callback()
being called on every registered service when only one service is removed.
