### PR TITLE
protocol: make counters shared among all processes.

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -12,7 +12,7 @@ from rpyc.lib.compat import pickle, next, is_py3k, maxint, select_error
 from rpyc.lib.colls import WeakValueDict, RefCountingColl
 from rpyc.core import consts, brine, vinegar, netref
 from rpyc.core.async import AsyncResult
-import rpyc.utils.multiprocessing
+import rpyc.utils.mp
 
 class PingError(Exception):
     """The exception raised should :func:`Connection.ping` fail"""
@@ -116,7 +116,7 @@ Parameter                                Default value     Description
 """
 
 
-_connection_id_generator = rpyc.utils.multiprocessing.count(1)
+_connection_id_generator = rpyc.utils.mp.count(1)
 
 class Connection(object):
     """The RPyC *connection* (AKA *protocol*).
@@ -140,7 +140,7 @@ class Connection(object):
             self._config["connid"] = "conn%d" % (next(_connection_id_generator),)
 
         self._channel = channel
-        self._seqcounter = rpyc.utils.multiprocessing.count()
+        self._seqcounter = rpyc.utils.mp.count()
         self._recvlock = Lock()
         self._sendlock = Lock()
         self._sync_replies = {}

--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -3,7 +3,6 @@ The RPyC protocol
 """
 import sys
 import weakref
-import itertools
 import socket
 import time
 import gc
@@ -13,6 +12,7 @@ from rpyc.lib.compat import pickle, next, is_py3k, maxint, select_error
 from rpyc.lib.colls import WeakValueDict, RefCountingColl
 from rpyc.core import consts, brine, vinegar, netref
 from rpyc.core.async import AsyncResult
+import rpyc.utils.multiprocessing
 
 class PingError(Exception):
     """The exception raised should :func:`Connection.ping` fail"""
@@ -116,7 +116,7 @@ Parameter                                Default value     Description
 """
 
 
-_connection_id_generator = itertools.count(1)
+_connection_id_generator = rpyc.utils.multiprocessing.count(1)
 
 class Connection(object):
     """The RPyC *connection* (AKA *protocol*).
@@ -140,7 +140,7 @@ class Connection(object):
             self._config["connid"] = "conn%d" % (next(_connection_id_generator),)
 
         self._channel = channel
-        self._seqcounter = itertools.count()
+        self._seqcounter = rpyc.utils.multiprocessing.count()
         self._recvlock = Lock()
         self._sendlock = Lock()
         self._sync_replies = {}

--- a/rpyc/utils/mp.py
+++ b/rpyc/utils/mp.py
@@ -1,12 +1,18 @@
 from multiprocessing import Value
 
+
 class count(object):
     def __init__(self, c=0):
         self.c = Value('L', c)
+
     def __iter__(self):
         return self
+
     def __next__(self):
         with self.c.get_lock():
             rv = self.c.value
             self.c.value += 1
         return rv
+
+    def next(self):
+        return self.__next__()

--- a/rpyc/utils/multiprocessing.py
+++ b/rpyc/utils/multiprocessing.py
@@ -1,0 +1,12 @@
+from multiprocessing import Value
+
+class count(object):
+    def __init__(self, c=0):
+        self.c = Value('L', c)
+    def __iter__(self):
+        return self
+    def __next__(self):
+        with self.c.get_lock():
+            rv = self.c.value
+            self.c.value += 1
+        return rv

--- a/tests/test_mp_count.py
+++ b/tests/test_mp_count.py
@@ -1,5 +1,5 @@
 import unittest
-from rpyc.utils.multiprocessing import count
+from rpyc.utils.mp import count
 from multiprocessing import Process
 
 class TestMpCount(unittest.TestCase):

--- a/tests/test_mp_count.py
+++ b/tests/test_mp_count.py
@@ -1,0 +1,27 @@
+import unittest
+from rpyc.utils.multiprocessing import count
+from multiprocessing import Process
+
+class TestMpCount(unittest.TestCase):
+    def setUp(self):
+        self.c = count(0)
+    def test_counter_increase(self):
+        def p_start(test_obj):
+            next(test_obj.c)
+        procs = []
+        for i in range(10):
+            p = Process(target=p_start, args=(self,))
+            procs.append(p)
+            p.start()
+        for p in procs:
+            p.join()
+        assert next(self.c) == 10
+
+    def test_counter_start_value(self):
+        c1 = count(1)
+        assert next(c1) == 1
+        assert next(c1) == 2
+        c = count()
+        assert next(c) == 0
+        assert next(c) == 1
+


### PR DESCRIPTION
Implement a drop-in replacement for `itertools.count()` that can be
safely `next()`'ed from any process. This prevents a case when
advancements of a counter within childs are not seen in their parent process.
Othewise (when `itertools.count()` is used), duplicated seq numbers appear
within the same connection.

I had a case when `list()` invoked on netref'ed list mistakenly added None to its end. When the client invoked `__next__` and was meant to receieve `StopIteration`, a reply with the same seq was in the `_sync_replies` so it returned wrong reply with None as its value.
