### PR TITLE
correct splitbrain module path in docs

### DIFF
--- a/docs/api/utils_splitbrain.rst
+++ b/docs/api/utils_splitbrain.rst
@@ -3,5 +3,5 @@
 Splitbrain Python
 =================
 
-.. automodule:: rpyc.utils.splitbrain
+.. automodule:: rpyc.experimental.splitbrain
    :members:


### PR DESCRIPTION
The splitbrain module is in `rpyc.experimental` in the package instead of `rpyc.utils` as in the documentation. This change allows Sphinx to find the module as intended.