### PR TITLE
connect client and server IP in TestUdpRegistry

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -63,11 +63,14 @@ class TestTcpRegistry(BaseRegistryTest, unittest.TestCase):
         return TCPRegistryClient("localhost")
 
 class TestUdpRegistry(BaseRegistryTest, unittest.TestCase):
+    ip = '0.0.0.0'
+    
     def _get_server(self):
-        return UDPRegistryServer(pruning_timeout=PRUNING_TIMEOUT)
+        return UDPRegistryServer(pruning_timeout=PRUNING_TIMEOUT,
+                                host=self.__class__.ip)
 
     def _get_client(self):
-        return UDPRegistryClient()
+        return UDPRegistryClient(ip=self.__class__.ip)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The client was never reaching the server since the former listened on 0.0.0.0 and the latter on 255.255.255.255. It is not clear why the tests seem to pass in CI logs but I can't get it to pass locally without this change.