### PR TITLE
Ensuring that we get a server we can connect to from the list.

### DIFF
--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -208,8 +208,22 @@ def connect_by_service(service_name, host = None, service = VoidService, config 
     :raises: ``DiscoveryError`` if no server is found
     :returns: an RPyC connection
     """
-    host, port = discover(service_name, host = host)[0]
-    return connect(host, port, service, config = config)
+    # The registry server may have multiple services registered for the same service name, 
+    # some of which could be dead. We iterate over the list returned and return the first 
+    # one we could connect to. If none of the registered servers is responsive we re-throw 
+    # the exception 
+    addrs = discover(service_name, host = host)
+    addrl = len(addrs)
+    for (host,port) in addrs:
+        try:
+            res = connect(host, port, service, config = config)
+            return res
+        except:
+            addrl -= 1
+            if addrl == 0:
+                raise
+            else:
+                pass
 
 def connect_subproc(args, service = VoidService, config = {}):
     """runs an rpyc server on a child process that and connects to it over

--- a/rpyc/version.py
+++ b/rpyc/version.py
@@ -1,4 +1,4 @@
-version = (3, 4, 2)
-version_string = "3.4.2"
+version = (3, 4, 4)
+version_string = "3.4.4"
 release_date = "2017.06.14"
 


### PR DESCRIPTION
Registry client returns first registry server it could connect to (instead of the first element of the list of all registered servers).