### PR TITLE
On call issue 239 fix

### DIFF
--- a/tests/test_dispatch_call.py
+++ b/tests/test_dispatch_call.py
@@ -5,7 +5,7 @@ import inspect
 import unittest
 
 class MyService(rpyc.Service):
-    def on_call(self, obj, args, kwargs):
+    def _dispatch_call(self, obj, args, kwargs):
         if inspect.isroutine(obj):
            return obj(*args, **kwargs)
         else:

--- a/tests/test_on_call.py
+++ b/tests/test_on_call.py
@@ -1,0 +1,41 @@
+#Test the on_call method hook of rpyc.Service
+
+import rpyc
+import inspect
+import unittest
+
+class MyService(rpyc.Service):
+    def on_call(self, obj, args, kwargs):
+        if inspect.isroutine(obj):
+           return obj(*args, **kwargs)
+        else:
+            raise TypeError("Non-routine types not callable remotely.")
+
+    def __call__(self):
+        return True
+
+    def exposed_test(self):
+        return True
+
+class TestCustomService(unittest.TestCase):
+    def setUp(self):
+        self.conn = rpyc.connect_thread(remote_service=MyService)
+        self.conn.root # this will block until the service is initialized,
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_on_call(self):
+        self.assertTrue(self.conn.root.test())
+        valid=False
+        try:
+            self.conn.root()
+        except TypeError as e:
+            self.assertTrue("remotely" in str(e))
+            valid=True
+        self.assertTrue(valid)
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
Issue #239 fix here. It could use some documentation being added, but thought I'd put it for debate first. This basically fixes it by checking the root service for an option "on_call" method, and if available, that method is used to dispatch the calls instead.

This is also one of 3 pull requests (PR #245, PR #246, PR #247) I am submitting that I need acceptance on to go forward with a large optional 3rd party support library for RPyC that adds allows for an enhanced security model.