### PR TITLE
Added on_box feature to support hooking box operations.

### DIFF
--- a/tests/test_on_box.py
+++ b/tests/test_on_box.py
@@ -1,0 +1,30 @@
+#Test the on_box method hook of rpyc.Service
+
+import rpyc
+import unittest
+
+class MyService(rpyc.Service):
+    def on_box(self, obj):
+        if obj == 2:
+            obj = None
+        return obj
+
+    def exposed_get_values(self):
+        return (1,3,4,5,2,6)
+
+class TestCustomService(unittest.TestCase):
+    def setUp(self):
+        self.conn = rpyc.connect_thread(remote_service=MyService)
+        self.conn.root # this will block until the service is initialized,
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_on_box(self):
+        x = self.conn.root.get_values()
+        self.assertTrue( x == (1,3,4,5,None,6) )
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
This adds a new feature that has not yet been discussed. The feature is the ability to intercept the boxing of objects on the server side. This is done by adding an optional "on_box" method to the service object. All objects that get boxed (brined or netref'd) get passed to this routine. The routine allows you to monitor boxing, and or change what object is actually being referred to by returning a different value. The main designed purpose of this is the capability to swap unexpectedly objects of a type with restricted versions of the same type, according to a security policy. 

This is one of 3 PRs (PR #245, PR #246, PR #247) needed to support a large 3rd party RPyC library for enhanced security.

Currently, all objects are passed to on_box. This is not strictly necessary, as it might be desirable to have only un-brineable objects passed. The code changes for that version would be slightly less invasive. However, the current version of the PR is as it is because I believe it is better from an api standpoint to intercept all boxed items. 

