### PR TITLE
Added exception filtering feature.

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -48,6 +48,7 @@ DEFAULT_CONFIG = dict(
     instantiate_custom_exceptions = False,
     import_custom_exceptions = False,
     instantiate_oldstyle_exceptions = False, # which don't derive from Exception
+    exception_filter_function = None,
     propagate_SystemExit_locally = False, # whether to propagate SystemExit locally or to the other party
     propagate_KeyboardInterrupt_locally = True,  # whether to propagate KeyboardInterrupt locally or to the other party
     log_exceptions = True,
@@ -93,6 +94,8 @@ Parameter                                Default value     Description
 ``instantiate_oldstyle_exceptions``      ``False``         Whether to allow instantiation of exceptions
                                                            which don't derive from ``Exception``. This
                                                            is not applicable for Python 3 and later.
+``exception_filter_function``            ``None``          Parameter is passed to :func:`rpyc.core.vinegar.load`
+                                                           to control what exceptions can be loaded.
 ``propagate_SystemExit_locally``         ``False``         Whether to propagate ``SystemExit``
                                                            locally (kill the server) or to the other
                                                            party (kill the client)
@@ -371,7 +374,8 @@ class Connection(object):
         obj = vinegar.load(raw,
             import_custom_exceptions = self._config["import_custom_exceptions"],
             instantiate_custom_exceptions = self._config["instantiate_custom_exceptions"],
-            instantiate_oldstyle_exceptions = self._config["instantiate_oldstyle_exceptions"])
+            instantiate_oldstyle_exceptions = self._config["instantiate_oldstyle_exceptions"],
+            exception_filter_function = self._config["exception_filter_function"])
         if seq in self._async_callbacks:
             self._async_callbacks.pop(seq)(True, obj)
         else:

--- a/tests/test_exception_filter.py
+++ b/tests/test_exception_filter.py
@@ -1,0 +1,89 @@
+#Test exception filtering
+
+import rpyc
+import unittest
+
+class CustomException1(Exception):
+    pass
+
+class CustomException2(Exception):
+    pass
+
+class MyService(rpyc.Service):
+    def exposed_value_error(self):
+        raise ValueError("Testing Value Error")
+
+    def exposed_type_error(self):
+        raise TypeError("Testing Type Error")
+
+    def exposed_custom_exception1(self):
+        raise CustomException1("Testing Custom Exception 1")
+
+    def exposed_custom_exception2(self):
+        raise CustomException2("Testing Custom Exception 2")
+
+class TestCustomService(unittest.TestCase):
+    def filter_exceptions(self, **kwargs):
+
+        self.assertTrue( "modname" in kwargs )
+        self.assertTrue( "clsname" in kwargs )
+        self.assertTrue( "attrs" in kwargs )
+        self.assertTrue( "tbtext" in kwargs )
+        self.assertTrue( "builtin" in kwargs )
+
+        if kwargs["builtin"]:
+            if kwargs["clsname"]=="TypeError":
+                return False
+            else:
+                return True
+        modname = kwargs["modname"]
+
+        if modname in ["__main__", "test_exception_filter"]:
+            if kwargs["clsname"]=="CustomException1":
+                return True
+        return False
+
+    def setUp(self):
+        config={"import_custom_exceptions":True,
+                "instantiate_custom_exceptions":True,
+                "exception_filter_function":self.filter_exceptions}
+        self.conn = rpyc.connect_thread(remote_service=MyService, config=config)
+        self.conn.root # this will block until the service is initialized,
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_exceptions(self):
+        valid=False
+        try:
+            self.conn.root.value_error()
+        except ValueError:
+            valid=True
+        self.assertTrue(valid)
+
+        valid=False
+        try:
+            self.conn.root.type_error()
+        except rpyc.core.vinegar.GenericException as e:
+            valid=True
+        self.assertTrue(valid)
+
+        valid=False
+        try:
+            self.conn.root.custom_exception1()
+        except CustomException1:
+            valid=True
+        self.assertTrue(valid)
+
+        valid=False
+        try:
+            self.conn.root.custom_exception2()
+        except rpyc.core.vinegar.GenericException as e:
+            valid=True
+        self.assertTrue(valid)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
This adds a yet undiscussed feature to allow enhanced exception filtering. Currently you can only filter exceptions based on a few global protocol flags. This PR adds the ability to use an optional callback function to control what functions are instantiated and/or module loaded by Vinegar.

This is one of 3 pull requests (PR #245, PR #246, PR #247) required by a large 3rd party extension to RPyC to allow for an extended security model. 
