### PR TITLE
Add VoidSlaveService

### DIFF
--- a/rpyc/core/service.py
+++ b/rpyc/core/service.py
@@ -182,3 +182,16 @@ class SlaveService(Service):
         return self._conn
 
 
+class VoidSlaveService(VoidService):
+    """The VoidSlaveService allows a remote peer to connect using SlaveService
+    wihtout exposing any local service."""
+
+    def __getattr__(self, name):
+        if name.startswith("exposed_"):
+            return self.void
+
+        return super(VoidSlaveService, self).__getattr__(name)
+
+    def void(*args, **kwargs):
+        pass
+


### PR DESCRIPTION
Add VoidSlaveService intended to be used by servers that doesn't want to expose any service but accept SlaveService connections.

For example, this server code:
```python
class Greeter(rpyc.utils.server.OneShotServer):
     def __init__(self, *args, **kwargs):
         super(Greeter, self).__init__(VoidSlaveService, *args, **kwargs)
     def _handle_connection(self, conn):
         remote_sys = conn.root.exposed_getmodule("sys")
         remote_sys.stdout.write("Hi\n")

Greeter(port=8888).start()
```
Allows a client to use `rpyc.classic.connect('localhost', 8888).serve_all()` and have it acting as a slave.

(Basically, rpyc classic back-connect)