### PR TITLE
Added __hash__ to _local_netref_attrs

### DIFF
--- a/rpyc/core/netref.py
+++ b/rpyc/core/netref.py
@@ -20,7 +20,7 @@ _local_netref_attrs = frozenset([
     '__dir__', '__doc__', '__getattr__', '__getattribute__', '__methods__',
     '__init__', '__metaclass__', '__module__', '__new__', '__reduce__',
     '__reduce_ex__', '__repr__', '__setattr__', '__slots__', '__str__',
-    '__weakref__', '__dict__', '__members__',  '__exit__',
+    '__weakref__', '__dict__', '__members__',  '__exit__', '__hash__',
 ]) | _deleted_netref_attrs
 """the set of attributes that are local to the netref object"""
 


### PR DESCRIPTION
Fixes https://github.com/tomerfiliba/rpyc/issues/280

I don't understand all the details, the issue is that the `__hash__` attribute is treated as `consts.HANDLE_CALLATTR` instead of `consts.HANDLE_HASH`