### PR TITLE
core.Channel.send upgrade: rate imporved

### DIFF
--- a/rpyc/core/channel.py
+++ b/rpyc/core/channel.py
@@ -70,6 +70,6 @@ class Channel(object):
             data = zlib.compress(data, self.COMPRESSION_LEVEL)
         else:
             compressed = 0
-        header = self.FRAME_HEADER.pack(len(data), compressed)
-        buf = header + data + self.FLUSHER
-        self.stream.write(buf)
+        self.stream.write(self.FRAME_HEADER.pack(len(data), compressed))
+        self.stream.write(data)
+        self.stream.write(self.FLUSHER)

--- a/rpyc/core/stream.py
+++ b/rpyc/core/stream.py
@@ -114,6 +114,7 @@ class SocketStream(Stream):
     MAX_IO_CHUNK = 64000  # read/write chunk is 64KB, too large of a value will degrade response for other clients
 
     def __init__(self, sock):
+        Stream.__init__(self)
         self.sock = sock
 
     @classmethod
@@ -278,6 +279,7 @@ class TunneledSocketStream(SocketStream):
     __slots__ = ("tun",)
 
     def __init__(self, sock):
+        SocketStream.__init__(self)
         self.sock = sock
         self.tun = None
 
@@ -294,6 +296,7 @@ class PipeStream(Stream):
     MAX_IO_CHUNK = 32000
 
     def __init__(self, incoming, outgoing):
+        Stream.__init__(self)
         outgoing.flush()
         self.incoming = incoming
         self.outgoing = outgoing
@@ -372,6 +375,7 @@ class Win32PipeStream(Stream):
     MAX_IO_CHUNK = 32000
 
     def __init__(self, incoming, outgoing):
+        Stream.__init__(self)
         import msvcrt
         self._keepalive = (incoming, outgoing)
         if hasattr(incoming, "fileno"):


### PR DESCRIPTION
Concatenation of bytes in python forces python to create a new continual memory area, which requires allocation of new memory and redundant copying of data. This commit fix it.
Also it may be useful to turn off compression. For example, when transmitting data very similar to Gaussian noise (or encryption, etc). 

Just try it to feel:
```
In [1]: import ctypes
In [2]: __data = memoryview(ctypes.create_string_buffer(1024 * 1024 * 1024)).tobytes()
In [3]: %timeit __new_data = b"b" + __data + b"e"
1 loop, best of 5: 362 ms per loop
```

# Test it.

## Server code:
```
import numpy, rpyc

rpyc.core.channel.zlib = False
rpyc.core.channel.Channel.COMPRESSION_LEVEL = 0
rpyc.core.stream.SocketStream.MAX_IO_CHUNK = 1024 * 1024 * 1024

def execute():
  m_data = numpy.ones(1024 * 1024 * 1024, dtype = numpy.int8).tobytes()

  class Service(rpyc.Service):
    def on_connect(self, connection): pass
    def on_disconnect(self, connection): pass
    def exposed_get_data(self): return m_data

  from rpyc.utils.server import ThreadedServer
  m_server = ThreadedServer(Service, port = 18861)
  m_server.start()

if "__main__" == __name__: execute()
```

## Client code:
```
import rpyc, time, ctypes, sys

rpyc.core.channel.zlib = False
rpyc.core.channel.Channel.COMPRESSION_LEVEL = 0
rpyc.core.stream.SocketStream.MAX_IO_CHUNK = 1024 * 1024 * 1024

def execute():
  m_connection = rpyc.connect("localhost", port = 18861, config = dict(sync_request_timeout = 60 * 5))
  m_remote = m_connection.root

  for m_index in range(8):
    m_begin = time.monotonic()
    m_size = len(m_remote.get_data())
    m_end = time.monotonic()
    m_duration = m_end - m_begin
    print("duration = {}, rate = {}, size = {}".format(m_duration, m_size / (m_duration * 1024 * 1024), m_size), file = sys.stderr)

if "__main__" == __name__: execute()
```

## With this patch:
```
duration = 1.4996376279996184, rate = 682.8316260415016, size = 1073741824
duration = 1.4744147909987078, rate = 694.5128373992943, size = 1073741824
duration = 1.604824550999183, rate = 638.0759811796531, size = 1073741824
duration = 1.5330151690031926, rate = 667.9646886115498, size = 1073741824
duration = 1.4718292850011494, rate = 695.7328614365764, size = 1073741824
duration = 1.5226827549995505, rate = 672.4972727495704, size = 1073741824
duration = 1.53084047199809, rate = 668.9135927164576, size = 1073741824
duration = 1.4800677439998253, rate = 691.8602233926671, size = 1073741824
```

## Without this patch:
```
duration = 1.8550147589994594, rate = 552.0171713093623, size = 1073741824
duration = 1.8554355170017516, rate = 551.8919901106071, size = 1073741824
duration = 1.9826194169982045, rate = 516.4884350574921, size = 1073741824
duration = 1.85964160200092, rate = 550.6437363512442, size = 1073741824
duration = 1.86007122799856, rate = 550.5165525848307, size = 1073741824
duration = 1.8557735280010093, rate = 551.7914683819346, size = 1073741824
duration = 1.8660566180005844, rate = 548.7507667892633, size = 1073741824
duration = 1.8541508239977702, rate = 552.2743817529007, size = 1073741824
```