### PR TITLE
Corrections to teleport example

### DIFF
--- a/docs/tutorial/tut1.rst
+++ b/docs/tutorial/tut1.rst
@@ -135,8 +135,9 @@ namespace::
 
 And the teleported code can also access the namespace::
 
-   >>> con.execute('import sys')
-   >>> conn.teleport(lambda: print(sys.version_info))
+   >>> conn.execute('import sys')
+   >>> version = conn.teleport(lambda: print(sys.version_info))
+   >>> version()
 
 prints the version on the remote terminal.
 


### PR DESCRIPTION
Fixed the teleport correction that had a typo and did not feel complete to a new user (new user being me in this case). Example now operates like the similar teleport example above it.