### PR TITLE
Fixed mutable object used as kwarg for Server ctor

### DIFF
--- a/rpyc/utils/server.py
+++ b/rpyc/utils/server.py
@@ -49,7 +49,7 @@ class Server(object):
 
     def __init__(self, service, hostname="", ipv6=False, port=0,
                  backlog=socket.SOMAXCONN, reuse_addr=True, authenticator=None, registrar=None,
-                 auto_register=None, protocol_config={}, logger=None, listener_timeout=0.5,
+                 auto_register=None, protocol_config=None, logger=None, listener_timeout=0.5,
                  socket_path=None):
         self.active = False
         self._closed = False
@@ -60,6 +60,10 @@ class Server(object):
             self.auto_register = bool(registrar)
         else:
             self.auto_register = auto_register
+
+        if protocol_config is None:
+            protocol_config = {}
+
         self.protocol_config = protocol_config
         self.clients = set()
 


### PR DESCRIPTION
Hello,
I am a security engineer at r2c.dev. We are working to write code
checks for security in open source code.

In python, the default values of function parameters are instantiated
at function definition time. All calls to that function that use the
default value all point to the same global object. e.g.:

```
def func(x=[]):
   x.append(1)
   print(x)

func() # [1]
func() # [1 , 1]
```

Because of this, two instances of Server (initialized without passing
in a protocol_config option) actually share the same protocol_config.
So modifying one server's config affects the other ones.

Fix:
The recommended solution is to either set default to None and assign
a new empty object when the variable is None.

We have a tool called Bento you can use for your project that continuously detects problems like this one. The check that identified this issue will be available in the very near future.
Thanks, and I hope this helps! Let me know if you have any questions.